### PR TITLE
Fixed issue with ordinal numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.5.1
+
++ [#19](https://github.com/luyadev/yii-helpers/pull/19) Fixed issue with ordinal numbers.
+
 ## 1.5.0 (26. October 2023)
 
 + Added new `StringHelper::toYouTubeEmbed()` function to extract YouTube links into an Embed links.

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -173,7 +173,7 @@ class StringHelper extends BaseStringHelper
             return true;
         }
 
-        if (preg_match('/\d+\./', $value)) {
+        if (!is_array($value) && preg_match('/^\d+\.$/', $value)) {
             // ordinal number of the form cardinal number followed by point, e.g. "24."
             return false;
         }

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -173,6 +173,11 @@ class StringHelper extends BaseStringHelper
             return true;
         }
 
+        if (preg_match('/\d+\./', $value)) {
+            // ordinal number of the form cardinal number followed by point, e.g. "24."
+            return false;
+        }
+
         return ($value == (string)(float) $value);
     }
 

--- a/tests/helpers/StringHelperTest.php
+++ b/tests/helpers/StringHelperTest.php
@@ -38,6 +38,9 @@ class StringHelperTest extends HelpersTestCase
         $this->assertTrue(StringHelper::isFloat('-1'));
         $float = 1.0;
         $this->assertTrue(StringHelper::isFloat($float));
+
+        $this->assertTrue(StringHelper::isFloat('.5'));
+        $this->assertFalse(StringHelper::isFloat('5.'));
         
         $this->assertFalse(StringHelper::isFloat('string'));
     }
@@ -53,6 +56,9 @@ class StringHelperTest extends HelpersTestCase
         $this->assertSame(1.5, StringHelper::typeCastNumeric(1.5));
         $this->assertSame(-1, StringHelper::typeCastNumeric(-1));
         $this->assertSame(-1.5, StringHelper::typeCastNumeric(-1.5));
+
+        $this->assertSame(0.5, StringHelper::typeCastNumeric('.5'));
+        $this->assertSame('5.', StringHelper::typeCastNumeric('5.'));
         
         $this->assertSame(1, StringHelper::typeCastNumeric(true));
         $this->assertSame(0, StringHelper::typeCastNumeric(false));


### PR DESCRIPTION
### What are you changing/introducing

Ordinal numbers of the form cardinal number followed by point, e.g. "24.", are not detected as floats by `StringHelper::isFloat()` any longer.
And so they are not casted to integers by `StringHelper::typeCastNumeric()`.

### What is the reason for changing/introducing

see issue #18 

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #18
